### PR TITLE
Add anti-grind caps to quiz reward path

### DIFF
--- a/src/__tests__/middlewares/checkAnswer.test.ts
+++ b/src/__tests__/middlewares/checkAnswer.test.ts
@@ -11,7 +11,7 @@
 import { mongoose } from '@typegoose/typegoose'
 import * as db from '../setup/db'
 import { makeCtx } from '../setup/contextFactory'
-import { checkAnswer, computeAccuracy } from '@/middlewares/checkAnswer'
+import { checkAnswer, computeAccuracy, MAX_MULTIPLIER, EARN_WINDOW_CAP } from '@/middlewares/checkAnswer'
 import { QuizModel } from '@/models/Quiz'
 import { getOrCreateUser, findUser, UserModel } from '@/models/User'
 import { upsertTopicMembership } from '@/models/TopicMembership'
@@ -582,5 +582,89 @@ describe('checkAnswer — async robustness', () => {
 
         process.off('unhandledRejection', onUnhandled)
         expect(unhandled).toHaveLength(0)
+    })
+})
+
+// --- anti-grind rate limiting / caps ---
+describe('checkAnswer — anti-grind caps', () => {
+    it('caps the multiplier used for reward at MAX_MULTIPLIER', async () => {
+        const { ctx } = await buildScenario({ solverId: 9001, authorId: 9002 })
+        // Simulate a legacy inflated streak.
+        ctx.dbuser.multiplier = 309
+
+        await checkAnswer(ctx, jest.fn())
+        await flush()
+
+        // Reward is computed as if multiplier were MAX_MULTIPLIER (10):
+        // totalReward = 100 + (100/10 * 10) = 200, Normal x1, solver 60% = 120.
+        expect(ctx.dbuser.balance).toBeCloseTo(200 * 0.6, 0)
+        // Stored streak is clamped, not incremented past the cap.
+        expect(ctx.dbuser.multiplier).toBe(MAX_MULTIPLIER)
+    })
+
+    it('does not let the streak grow past MAX_MULTIPLIER on a correct answer', async () => {
+        const { ctx } = await buildScenario({ solverId: 9011, authorId: 9012 })
+        ctx.dbuser.multiplier = MAX_MULTIPLIER
+
+        await checkAnswer(ctx, jest.fn())
+        await flush()
+
+        expect(ctx.dbuser.multiplier).toBe(MAX_MULTIPLIER)
+    })
+
+    it('suppresses reward and notifications when answering too fast', async () => {
+        const { ctx, authorId } = await buildScenario({ solverId: 9101, authorId: 9102 })
+        // Last rewarded answer was effectively "just now".
+        ctx.dbuser.lastAnsweredAt = new Date()
+        const quizId = ctx.dbuser.quizId!.toString()
+
+        await checkAnswer(ctx, jest.fn())
+        await flush()
+
+        expect(ctx.dbuser.balance).toBe(0)
+        const recipients = ctx.api.sendMessage.mock.calls.map((c: any[]) => c[0])
+        expect(recipients).not.toContain(9101) // no solver notification
+        expect(recipients).not.toContain(9102) // no author notification (no spam)
+        const authorDb = await findUser(authorId)
+        expect(authorDb!.balance).toBe(0)
+        // Quiz is still consumed so it isn't re-served (quizId is cleared after).
+        expect(ctx.dbuser.answered.map((id: any) => id.toString())).toContain(quizId)
+    })
+
+    it('suppresses reward when the per-window cap is exhausted', async () => {
+        const { ctx } = await buildScenario({ solverId: 9201, authorId: 9202 })
+        ctx.dbuser.earnWindowStart = new Date()
+        ctx.dbuser.earnWindowCount = EARN_WINDOW_CAP
+
+        await checkAnswer(ctx, jest.fn())
+        await flush()
+
+        expect(ctx.dbuser.balance).toBe(0)
+        const recipients = ctx.api.sendMessage.mock.calls.map((c: any[]) => c[0])
+        expect(recipients).not.toContain(9201)
+    })
+
+    it('resets the window and rewards once the window has elapsed', async () => {
+        const { ctx } = await buildScenario({ solverId: 9301, authorId: 9302 })
+        // Window started long ago and was previously maxed out.
+        ctx.dbuser.earnWindowStart = new Date(Date.now() - 2 * 60 * 60 * 1000)
+        ctx.dbuser.earnWindowCount = EARN_WINDOW_CAP
+
+        await checkAnswer(ctx, jest.fn())
+        await flush()
+
+        // Fresh window: rewarded normally and counter restarts at 1.
+        expect(ctx.dbuser.balance).toBeCloseTo(60, 0)
+        expect(ctx.dbuser.earnWindowCount).toBe(1)
+    })
+
+    it('records tracking fields on a normal rewarded answer', async () => {
+        const { ctx } = await buildScenario({ solverId: 9401, authorId: 9402 })
+
+        await checkAnswer(ctx, jest.fn())
+        await flush()
+
+        expect(ctx.dbuser.lastAnsweredAt).toBeInstanceOf(Date)
+        expect(ctx.dbuser.earnWindowCount).toBe(1)
     })
 })

--- a/src/middlewares/checkAnswer.ts
+++ b/src/middlewares/checkAnswer.ts
@@ -9,6 +9,20 @@ export const nextQuestionKeyboard = {
     inline_keyboard: [[{ text: "Следующий квиз", callback_data: "next_quiz" }]]
 }
 
+// Anti-grind limits. Telegram quiz polls deliver the correct option to the
+// client, so a scripted client can always answer correctly — "is the answer
+// right" can never be trusted as proof-of-work. These caps bound how fast and
+// how much any single account can extract, regardless of correctness.
+//
+// MAX_MULTIPLIER caps the streak bonus so a full quiz-bank clear can't balloon
+// a balance (an uncapped streak previously reached ~6,380 points/answer).
+// MIN_ANSWER_INTERVAL_MS rejects burst answering faster than a human could read.
+// EARN_WINDOW_CAP bounds rewarded answers per EARN_WINDOW_MS window.
+export const MAX_MULTIPLIER = 10
+export const MIN_ANSWER_INTERVAL_MS = 3000
+export const EARN_WINDOW_MS = 60 * 60 * 1000
+export const EARN_WINDOW_CAP = 60
+
 export function computeAccuracy(
     pickedIndices: number[],
     correctIndices: number[],
@@ -71,103 +85,139 @@ export async function checkAnswer(ctx: MyContext, next: NextFunction) {
         const accuracy = computeAccuracy(pickedIndices, correctIndices, options.length)
 
         if (pickedIndices.length > 0 && accuracy > 0) {
-            const baseValue = 100
-            let totalReward = baseValue + (baseValue / 10 * user.multiplier)
-            switch ((ctx.dbuser as User).difficulty) {
-                case Difficulty.Easy:
-                    totalReward = totalReward * 0.5
-                    break
-                case Difficulty.Hard:
-                    totalReward = totalReward * 1.5
-                    break
-                case Difficulty.Nightmare:
-                    totalReward = totalReward * 2
-                    break
-                default:
-                    totalReward = totalReward * 1
-                    break
+            const now = new Date()
+
+            // Normalize any legacy over-cap streak so existing inflated
+            // multipliers can't keep paying out at the old uncapped rate.
+            // (Balances are intentionally left untouched.)
+            if (user.multiplier > MAX_MULTIPLIER) {
+                user.multiplier = MAX_MULTIPLIER
             }
 
-            totalReward = totalReward * accuracy
+            // Anti-grind gates: reject answers that arrive faster than a human
+            // could read, or beyond the per-window cap.
+            const tooFast = user.lastAnsweredAt != null &&
+                now.getTime() - user.lastAnsweredAt.getTime() < MIN_ANSWER_INTERVAL_MS
+            let windowStart = user.earnWindowStart
+            let windowCount = user.earnWindowCount ?? 0
+            if (windowStart == null || now.getTime() - windowStart.getTime() >= EARN_WINDOW_MS) {
+                windowStart = now
+                windowCount = 0
+            }
+            const overCap = windowCount >= EARN_WINDOW_CAP
 
-            // Determine inviter for this quiz's section
-            let inviterId = 0
-            let authorId: number | null = null
-            if (user.quizId) {
-                const quiz = await findQuizById(user.quizId.toString())
-                if (quiz) {
-                    authorId = quiz.authorId
-                    if (quiz.sectionId) {
-                        inviterId = await getInviterForTopic(quiz.sectionId, user.id)
+            if (tooFast || overCap) {
+                // Consume the quiz so it isn't re-served, but pay nothing and
+                // notify no one (this is what stops the reward-notification
+                // spam from a grinder). Break the streak to discourage bursts.
+                console.log(`Rate-limited reward for user ${user.id} (tooFast=${tooFast}, overCap=${overCap})`)
+                user.multiplier = 0
+                user.lastAnsweredAt = now
+                user.earnWindowStart = windowStart
+                user.earnWindowCount = windowCount
+                user.answered.push(user.quizId)
+            } else {
+                const baseValue = 100
+                let totalReward = baseValue + (baseValue / 10 * user.multiplier)
+                switch ((ctx.dbuser as User).difficulty) {
+                    case Difficulty.Easy:
+                        totalReward = totalReward * 0.5
+                        break
+                    case Difficulty.Hard:
+                        totalReward = totalReward * 1.5
+                        break
+                    case Difficulty.Nightmare:
+                        totalReward = totalReward * 2
+                        break
+                    default:
+                        totalReward = totalReward * 1
+                        break
+                }
+
+                totalReward = totalReward * accuracy
+
+                // Determine inviter for this quiz's section
+                let inviterId = 0
+                let authorId: number | null = null
+                if (user.quizId) {
+                    const quiz = await findQuizById(user.quizId.toString())
+                    if (quiz) {
+                        authorId = quiz.authorId
+                        if (quiz.sectionId) {
+                            inviterId = await getInviterForTopic(quiz.sectionId, user.id)
+                        }
                     }
                 }
+
+                // Distribute rewards
+                const hasInviter = inviterId > 0 && inviterId !== user.id
+
+                let solverReward: number
+                let authorReward: number
+                let inviterReward: number
+
+                if (hasInviter) {
+                    // Topic invite mode: 40% solver, 40% author, 20% inviter
+                    solverReward = totalReward * 0.40
+                    authorReward = totalReward * 0.40
+                    inviterReward = totalReward * 0.20
+                } else {
+                    // Free-play or no inviter: 60% solver, 40% author
+                    solverReward = totalReward * 0.60
+                    authorReward = totalReward * 0.40
+                    inviterReward = 0
+                }
+
+                // Pay solver
+                user.balance = user.balance + solverReward
+                if (accuracy === 1.0) {
+                    user.multiplier = Math.min(user.multiplier + 1, MAX_MULTIPLIER)
+                } else {
+                    user.multiplier = 0
+                }
+                console.log(`Add ${solverReward} to solver ${user.id} (accuracy ${accuracy}, total reward ${totalReward}, now ${user.balance})`)
+                ctx.api.sendMessage(user.id, ctx.i18n.t('success_pay_for_answer', { score: Math.round(solverReward), balance: Math.round(user.balance) }))
+                    .catch(err => console.error(`Failed to notify solver ${user.id}`, err))
+
+                // Pay author (background, if different from solver)
+                if (authorId !== null && authorId !== user.id) {
+                    addToBalance(authorId, authorReward)
+                        .then(() => findUser(authorId))
+                        .then(author => {
+                            if (author) {
+                                return ctx.api.sendMessage(author.id, ctx.i18n.t('success_pay_for_quiz_answer', {
+                                    score: Math.round(authorReward),
+                                    balance: Math.round(author.balance)
+                                }))
+                            }
+                        })
+                        .catch(err => console.error(`Failed to pay/notify author ${authorId}`, err))
+                } else if (authorId === user.id) {
+                    // Solver is also the author — add both portions to the same user
+                    user.balance = user.balance + authorReward
+                    console.log(`Solver is also author — added ${authorReward} more (now ${user.balance})`)
+                }
+
+                // Pay inviter (background, if present and different from solver)
+                if (hasInviter) {
+                    addToBalance(inviterId, inviterReward)
+                        .then(() => findUser(inviterId))
+                        .then(inviter => {
+                            if (inviter) {
+                                return ctx.api.sendMessage(inviter.id, ctx.i18n.t('success_pay_as_inviter', {
+                                    score: Math.round(inviterReward),
+                                    balance: Math.round(inviter.balance)
+                                }))
+                            }
+                        })
+                        .catch(err => console.error(`Failed to pay/notify inviter ${inviterId}`, err))
+                }
+
+                user.answered.push(user.quizId)
+                user.lastAnsweredAt = now
+                user.earnWindowStart = windowStart
+                user.earnWindowCount = windowCount + 1
             }
-
-            // Distribute rewards
-            const hasInviter = inviterId > 0 && inviterId !== user.id
-
-            let solverReward: number
-            let authorReward: number
-            let inviterReward: number
-
-            if (hasInviter) {
-                // Topic invite mode: 40% solver, 40% author, 20% inviter
-                solverReward = totalReward * 0.40
-                authorReward = totalReward * 0.40
-                inviterReward = totalReward * 0.20
-            } else {
-                // Free-play or no inviter: 60% solver, 40% author
-                solverReward = totalReward * 0.60
-                authorReward = totalReward * 0.40
-                inviterReward = 0
-            }
-
-            // Pay solver
-            user.balance = user.balance + solverReward
-            if (accuracy === 1.0) {
-                user.multiplier = user.multiplier + 1
-            } else {
-                user.multiplier = 0
-            }
-            console.log(`Add ${solverReward} to solver ${user.id} (accuracy ${accuracy}, total reward ${totalReward}, now ${user.balance})`)
-            ctx.api.sendMessage(user.id, ctx.i18n.t('success_pay_for_answer', { score: Math.round(solverReward), balance: Math.round(user.balance) }))
-                .catch(err => console.error(`Failed to notify solver ${user.id}`, err))
-
-            // Pay author (background, if different from solver)
-            if (authorId !== null && authorId !== user.id) {
-                addToBalance(authorId, authorReward)
-                    .then(() => findUser(authorId))
-                    .then(author => {
-                        if (author) {
-                            return ctx.api.sendMessage(author.id, ctx.i18n.t('success_pay_for_quiz_answer', {
-                                score: Math.round(authorReward),
-                                balance: Math.round(author.balance)
-                            }))
-                        }
-                    })
-                    .catch(err => console.error(`Failed to pay/notify author ${authorId}`, err))
-            } else if (authorId === user.id) {
-                // Solver is also the author — add both portions to the same user
-                user.balance = user.balance + authorReward
-                console.log(`Solver is also author — added ${authorReward} more (now ${user.balance})`)
-            }
-
-            // Pay inviter (background, if present and different from solver)
-            if (hasInviter) {
-                addToBalance(inviterId, inviterReward)
-                    .then(() => findUser(inviterId))
-                    .then(inviter => {
-                        if (inviter) {
-                            return ctx.api.sendMessage(inviter.id, ctx.i18n.t('success_pay_as_inviter', {
-                                score: Math.round(inviterReward),
-                                balance: Math.round(inviter.balance)
-                            }))
-                        }
-                    })
-                    .catch(err => console.error(`Failed to pay/notify inviter ${inviterId}`, err))
-            }
-
-            user.answered.push(user.quizId)
         } else {
             console.log(`Incorrect answer for user ${user.id}`)
             user.multiplier = 0

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -37,6 +37,17 @@ export class User {
   @prop({ required: true, default: 0 })
   multiplier: number
 
+  // Anti-grind rate limiting (see checkAnswer). Timestamp of the last rewarded
+  // answer, plus a rolling window counter that caps rewarded answers per period.
+  @prop({ required: false })
+  lastAnsweredAt?: Date
+
+  @prop({ required: false })
+  earnWindowStart?: Date
+
+  @prop({ required: true, default: 0 })
+  earnWindowCount: number
+
   @prop({ required: true, default: new Date(0) })
   notifiedAt: Date
 


### PR DESCRIPTION
## Why

A scripted Telegram client can read a quiz poll's `correct_option_id` and grind payouts — observed in prod on 2026-06-18: ~1 correct answer every 3s, 100% accuracy, clearing the entire 310-quiz bank. With an **uncapped multiplier**, balances ballooned to ~1,000,000 (multiplier reached 309). Withdrawals pay `balance × (chainVIZ ÷ Σ all balances)`, so inflated balances drain the shared on-chain VIZ pool (~395 VIZ withdrawn by coordinated accounts in the log window). The author-side 40% `success_pay_for_quiz_answer` notifications generated by the grind also spammed quiz authors.

This is **not** a regression of the 36b4823 poll-redelivery fix (that remains intact). It's a separate abuse vector.

## Approach

Telegram quiz polls deliver the correct option to the client, so "is the answer correct" can never be proof-of-work. Instead of trying to verify correctness, **bound extraction with caps**:

- `MAX_MULTIPLIER = 10` — caps the streak bonus, and clamps any legacy over-cap multiplier going forward (per-answer reward drops from ~6,380 to ~400). **Existing balances are intentionally left untouched.**
- `MIN_ANSWER_INTERVAL_MS = 3000` — rejects burst answering faster than a human could read.
- `EARN_WINDOW_CAP = 60` per `EARN_WINDOW_MS` (1h) — bounds rewarded answers per rolling window.

Over-limit answers are **consumed** (so they aren't re-served) but pay nothing and send **no notifications** — which is also what stops the author-notification spam.

## Changes

- `src/middlewares/checkAnswer.ts` — caps + rate-limit gate (tunable constants at top).
- `src/models/User.ts` — new fields `lastAnsweredAt`, `earnWindowStart`, `earnWindowCount`.
- `src/__tests__/middlewares/checkAnswer.test.ts` — 6 new tests.

## Decisions (deliberately out of scope)

- **No bans** and **no balance reset** — existing inflated balances remain a residual exposure if those accounts withdraw.
- Noted-but-not-fixed: `answered.includes(quizId)` on `ObjectId[]` is reference-equality (always false) at `checkAnswer.ts:41` / `sendQuiz.ts:108`; harmless because re-serve is gated by `\$nin` in `Quiz.ts`.

## Tests

`yarn build-ts` clean. `yarn test` → **147/147 pass** (was 141).

🤖 Generated with [Claude Code](https://claude.com/claude-code)